### PR TITLE
config: add newest incs and srcs for google/brotli

### DIFF
--- a/config
+++ b/config
@@ -78,6 +78,7 @@ ngx_module_deps="$brotli/common/constants.h \
                  $brotli/common/dictionary.h \
                  $brotli/common/version.h \
                  $brotli/enc/backward_references.h \
+                 $brotli/enc/backward_references_hq.h \
                  $brotli/enc/backward_references_inc.h \
                  $brotli/enc/bit_cost.h \
                  $brotli/enc/bit_cost_inc.h \
@@ -98,6 +99,7 @@ ngx_module_deps="$brotli/common/constants.h \
                  $brotli/enc/find_match_length.h \
                  $brotli/enc/hash_forgetful_chain_inc.h \
                  $brotli/enc/hash.h \
+                 $brotli/enc/hash_to_binary_tree_inc.h \
                  $brotli/enc/hash_longest_match_inc.h \
                  $brotli/enc/hash_longest_match_quickly_inc.h \
                  $brotli/enc/histogram.h \
@@ -116,12 +118,14 @@ ngx_module_deps="$brotli/common/constants.h \
                  $brotli/enc/write_bits.h"
 ngx_module_srcs="$brotli/common/dictionary.c \
                  $brotli/enc/backward_references.c \
+                 $brotli/enc/backward_references_hq.c \
                  $brotli/enc/bit_cost.c \
                  $brotli/enc/block_splitter.c \
                  $brotli/enc/brotli_bit_stream.c \
                  $brotli/enc/cluster.c \
                  $brotli/enc/compress_fragment.c \
                  $brotli/enc/compress_fragment_two_pass.c \
+                 $brotli/enc/dictionary_hash.c \
                  $brotli/enc/encode.c \
                  $brotli/enc/entropy_encode.c \
                  $brotli/enc/histogram.c \


### PR DESCRIPTION
Hello @PiotrSikora 

The [google/brotli](https://github.com/google/brotli) master branch added new files from this [PR](https://github.com/google/brotli/commit/11df843cf019e0a18f5efce660693a30f487fb06). Now the master branch of [google/ngx_brotli](https://github.com/google/ngx_brotli) cannot be compiled because of lack of newest incs and srcs.