### PR TITLE
Mention 'brotli_comp_level' is for on the fly

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This is either `4k` or `8k`, depending on a platform.
 - **default**: `6`
 - **context**: `http`, `server`, `location`
 
-Sets Brotli quality (compression) `level`.
+Sets on-the-fly compression Brotli quality (compression) `level`.
 Acceptable values are in the range from `0` to `11`.
 
 ### `brotli_window`


### PR DESCRIPTION
Specify that 'brotli_comp_level' is for on the fly responses only - avoids people trying to set it for brotli_static is enabled (might be obvious when you think about it, but I missed it!)