### PR TITLE
Update to build against brotli 0.6.0

### DIFF
--- a/config
+++ b/config
@@ -116,12 +116,14 @@ ngx_module_deps="$brotli/common/constants.h \
                  $brotli/enc/write_bits.h"
 ngx_module_srcs="$brotli/common/dictionary.c \
                  $brotli/enc/backward_references.c \
+                 $brotli/enc/backward_references_hq.c \
                  $brotli/enc/bit_cost.c \
                  $brotli/enc/block_splitter.c \
                  $brotli/enc/brotli_bit_stream.c \
                  $brotli/enc/cluster.c \
                  $brotli/enc/compress_fragment.c \
                  $brotli/enc/compress_fragment_two_pass.c \
+                 $brotli/enc/dictionary_hash.c \
                  $brotli/enc/encode.c \
                  $brotli/enc/entropy_encode.c \
                  $brotli/enc/histogram.c \


### PR DESCRIPTION
A number of symbols have been refactored into new source files in brotli 0.6.0. This commit simply links those necessary files to build ngx_brotli against the brotli-0.6.0 sources.