### PR TITLE
Fix #80

### DIFF
--- a/filter/ngx_http_brotli_filter_module.c
+++ b/filter/ngx_http_brotli_filter_module.c
@@ -336,6 +336,7 @@ static ngx_int_t ngx_http_brotli_body_filter(ngx_http_request_t* r,
   int rc;
   ngx_http_brotli_ctx_t* ctx;
   size_t available_output;
+  ptrdiff_t unconsumed_output;
   size_t input_size;
   size_t available_input;
   const uint8_t* next_input_byte;
@@ -375,6 +376,7 @@ static ngx_int_t ngx_http_brotli_body_filter(ngx_http_request_t* r,
      - if there is more input - push it to encoder */
   for (;;) {
     if (ctx->output_busy || ctx->output_ready) {
+      unconsumed_output = ngx_buf_size(ctx->out_buf);
       rc = ngx_http_next_body_filter(r,
                                      ctx->output_ready ? ctx->out_chain : NULL);
       if (ctx->output_ready) {
@@ -385,6 +387,9 @@ static ngx_int_t ngx_http_brotli_body_filter(ngx_http_request_t* r,
         ctx->output_busy = 0;
       }
       if (rc == NGX_OK) {
+        if (ctx->output_busy && ngx_buf_size(ctx->out_buf) == unconsumed_output) {
+          return NGX_AGAIN;
+        }
         continue;
       } else if (rc == NGX_AGAIN) {
         if (ctx->output_busy) {


### PR DESCRIPTION
Prevent spinning when other filter modules return NGX_OK but fail to
make progress.