### PR TITLE
Fix 'Vary' header

### DIFF
--- a/static/ngx_http_brotli_static_module.c
+++ b/static/ngx_http_brotli_static_module.c
@@ -162,15 +162,15 @@ static ngx_int_t handler(ngx_http_request_t* req) {
 
   /* Get configuration and check if module is disabled. */
   cfg = ngx_http_get_module_loc_conf(req, ngx_http_brotli_static_module);
-  if (cfg->enable == NGX_HTTP_BROTLI_STATIC_OFF) return NGX_DECLINED;
+  if (cfg->enable == NGX_HTTP_BROTLI_STATIC_OFF) {
+    return NGX_DECLINED;
+  }
 
-  if (cfg->enable == NGX_HTTP_BROTLI_STATIC_ALWAYS) {
-    /* Ignore request properties (e.g. Accept-Encoding). */
-  } else {
-    /* NGX_HTTP_BROTLI_STATIC_ON */
-    req->gzip_vary = 1;
+  if (cfg->enable == NGX_HTTP_BROTLI_STATIC_ON) {
     rc = check_eligility(req);
     if (rc != NGX_OK) return NGX_DECLINED;
+  } else {
+        /* always */
   }
 
   /* Get path and append the suffix. */
@@ -225,6 +225,14 @@ static ngx_int_t handler(ngx_http_request_t* req) {
     ngx_log_error(level, log, file_info.err, "%s \"%s\" failed",
                   file_info.failed, path.data);
     return NGX_DECLINED;
+  }
+
+  if (cfg->enable == NGX_HTTP_BROTLI_STATIC_ON) {
+	 req->gzip_vary = 1;
+
+	 if (rc != NGX_OK) {
+		return NGX_DECLINED;
+	 }
   }
 
   /* So far so good. */


### PR DESCRIPTION
Here is a patch regarding the issue I recently posted: #97  I used the nginx gzip_static module as a comparison since I know it works as-expected. I've tested this on my dev server and happy to report that it is no longer setting the header for images. It is correctly dynamically compressing content, and also correctly sending pre-compressed static files.

The only thing I'm not sure about is under 'NGX_HTTP_BROTLI_STATIC_ALWAYS', there's just the `/* always */` comment. In the gzip_static module there is also `rc = NGX_OK;` which I'm not 100% sure if it should be there or not. I left it out (since I don't use the `always` option). Maybe it should be there?