### PR TITLE
Fix #116: Static brotli overrides dynamic gzip

### DIFF
--- a/script/.travis-before-test.sh
+++ b/script/.travis-before-test.sh
@@ -4,6 +4,7 @@ set -ex
 # Setup shortcuts.
 ROOT=`pwd`
 FILES=$ROOT/script/test
+BROTLI=$ROOT/deps/brotli/out/brotli
 
 # Setup directory structure.
 cd $ROOT/script
@@ -19,6 +20,8 @@ fi
 curl --compressed -o $FILES/war-and-peace.txt http://www.gutenberg.org/files/2600/2600-0.txt
 echo "Kot lomom kolol slona!" > $FILES/small.txt
 echo "<html>Kot lomom kolol slona!</html>" > $FILES/small.html
+
+$BROTLI $FILES/small.html
 
 # Restore status-quo.
 cd $ROOT

--- a/script/test_static.conf
+++ b/script/test_static.conf
@@ -1,0 +1,30 @@
+events {
+  worker_connections 4;
+}
+
+daemon on;
+error_log /dev/stdout info;
+
+http {
+  access_log ./access.log;
+  error_log ./error.log;
+
+  gzip on;
+  gzip_comp_level 1;
+  gzip_types text/plain text/css;
+
+  brotli_static on;
+
+  server {
+    listen 8080 default_server;
+    listen [::]:8080 default_server;
+
+    root ./;
+
+    index index.html;
+
+    location / {
+      try_files $uri $uri/ =404;
+    }
+  }
+}

--- a/static/ngx_http_brotli_static_module.c
+++ b/static/ngx_http_brotli_static_module.c
@@ -136,8 +136,6 @@ static ngx_int_t check_accept_encoding(ngx_http_request_t* req) {
 static ngx_int_t check_eligility(ngx_http_request_t* req) {
   if (req != req->main) return NGX_DECLINED;
   if (check_accept_encoding(req) != NGX_OK) return NGX_DECLINED;
-  req->gzip_tested = 1;
-  req->gzip_ok = 0;
   return NGX_OK;
 }
 
@@ -243,6 +241,10 @@ static ngx_int_t handler(ngx_http_request_t* req) {
     return NGX_HTTP_NOT_FOUND;
   }
 #endif
+
+  /* Prevent gzip from overriding */
+  req->gzip_tested = 1;
+  req->gzip_ok = 0;
 
   /* Prepare request push the body. */
   req->root_tested = !req->error_page;


### PR DESCRIPTION
See https://github.com/google/ngx_brotli/issues/116#issuecomment-814880806

Adds two tests:
1. static .br files are served: this downloads a file that has a static .br and compares it to the static .br on disk.
     * This test passes without this patch, it is included to add a little testing to the static module.
2. dynamic gzip is used when .br doesn't exist: this downloads a file that does _not_ have a static .br file, and ensures it is gzip compressed.
     * Without this patch, the test should fail.