### PR TITLE
Added version tagging for master commits

### DIFF
--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -1,0 +1,30 @@
+name: tag-release
+on:
+  push:
+    # Tag a release upon pushing code to the master branch
+    branches:
+      - master
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - name: Get Short SHA Of Last Commit
+        id: short
+        run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+
+      - name: Bump Version And Push Tag
+        uses: anothrNick/github-tag-action@1.56.0
+        id: tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BUMP: patch
+          INITIAL_VERSION: 1.0.0
+          WITH_V: true
+
+      - name: Print Results
+        run: echo "Tagged Commit ${{ steps.short.outputs.sha_short }} With Tag ${{ steps.tag.outputs.tag }}"


### PR DESCRIPTION
Currently, it is extremely difficult to audit changes in this repository due to the fact that there is no sort of tagging when code is committed to the master branch of this repository.  Therefore there is no way to know what exact version of ngx_brotli your using when downloading from GitHub unless you use a SHA of some sort, which is unwieldy.

Therefore this PR adds a GitHub Action to update a tag on the repo every time a commit is made to master.  That way there is a tag to reference on each change in master, allowing for easier audibility of the repository.

Also resolves issues pointed out around tagging in Issue #120.