### PR TITLE
Fix msvc build (ngx_brotli module for windows)

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -128,6 +128,8 @@ fi
 
 if [ "$NGX_MSVC_VER" = "" ]; then
     CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+else  # MSVC
+    CFLAGS="$CFLAGS -Y- -wd4127 -wd4189 -wd4201 -wd4334 -wd4702"
 fi
 
 have=NGX_HTTP_BROTLI_FILTER . auto/have

--- a/filter/config
+++ b/filter/config
@@ -126,7 +126,9 @@ if [ "$ngx_module_link" != DYNAMIC ]; then
                          | sed "s/$next/$next $ngx_module_name/"`
 fi
 
-CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+if [ "$NGX_MSVC_VER" = "" ]; then
+    CFLAGS="$CFLAGS -Wno-deprecated-declarations"
+fi
 
 have=NGX_HTTP_BROTLI_FILTER . auto/have
 have=NGX_HTTP_BROTLI_FILTER_MODULE . auto/have  # deprecated


### PR DESCRIPTION
Suggested PR fixes build of ngx_brotli module for windows with msvc compiler & toolchain.

* avoid error `cl : Command line error D8021 : invalid numeric argument '/Wno-deprecated-declarations'`
* suppress warnings (that cause fatal error after all with `-W4` used by default build for windows):
  - `C4127` conditional expression is constant
  - `C4189` local variable is initialized but not referenced
  - `C4201` nonstandard extension used : nameless struct/union
  - `C4334` result of 32-bit shift implicitly converted to 64 bits
  - `C4702` unreachable code
* disable precompiled header (otherwise it fails since no common precompile header included in brotli files)

**Cons:** it changes `CFLAGS` for whole nginx `Makefile`, so it'd suppress the warnings and disables precompiled header in entire build process of nginx (not ngx_brotli module only) no matter the module added as dynamic or static.
I did not find the way how using `auto/module` one could set it for brotli-deps files only (if it is possible at all). Another possibility would be to build brotli-deps as a static library in a separate process and link it statically to ngx_brotli module hereafter.

This PR fixes it minimal invasive, similar the tweak with `CFLAGS="$CFLAGS -Wno-deprecated-declarations"` which has alike effect (just ignores deprecated declarations) for entire build process of nginx. Anyway it works after all.