### PR TITLE
Fix broken brotli build (upstream brotli dropped makefile support and sources.lst file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Both Brotli library and nginx module are under active development.
 
 ### Statically compiled
 
-Chechout the latest `ngx_brotli` and build the dependencies
+Checkout the latest `ngx_brotli` and build the dependencies:
 
 ```
 git clone --recurse-submodules -j8 https://github.com/google/ngx_brotli

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ ngx_brotli is a set of two nginx modules:
 - ngx_brotli filter module - used to compress responses on-the-fly,
 - ngx_brotli static module - used to serve pre-compressed files.
 
-[![TravisCI Build Status](https://travis-ci.org/google/ngx_brotli.svg?branch=master)](https://travis-ci.org/google/ngx_brotli)
 
 ## Table of Contents
 
@@ -37,6 +36,29 @@ Both Brotli library and nginx module are under active development.
 
 ## Installation
 
+### Statically compiled
+
+Chechout the latest `ngx_brotli` and build the dependencies
+
+```
+git clone --recurse-submodules -j8 https://github.com/google/ngx_brotli
+cd ngx_brotli/deps/brotli
+mkdir out && cd out
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_CXX_FLAGS="-Ofast -m64 -march=native -mtune=native -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections" -DCMAKE_INSTALL_PREFIX=./installed ..
+cmake --build . --config Release --target brotlienc
+cd ../../../..
+```
+
+
+    $ cd nginx-1.x.x
+    $ export CFLAGS="-m64 -march=native -mtune=native -Ofast -flto -funroll-loops -ffunction-sections -fdata-sections -Wl,--gc-sections"
+    $ export LDFLAGS="-m64 -Wl,-s -Wl,-Bsymbolic -Wl,--gc-sections"
+    $ ./configure --add-module=/path/to/ngx_brotli
+    $ make && make install
+  
+This will compile the module directly into Nginx.
+
+
 ### Dynamically loaded
 
     $ cd nginx-1.x.x
@@ -51,13 +73,7 @@ load_module modules/ngx_http_brotli_filter_module.so;
 load_module modules/ngx_http_brotli_static_module.so;
 ```
 
-### Statically compiled
 
-    $ cd nginx-1.x.x
-    $ ./configure --add-module=/path/to/ngx_brotli
-    $ make && make install
-  
-This will compile the module directly into Nginx.
 
 ## Configuration directives
 

--- a/filter/config
+++ b/filter/config
@@ -44,12 +44,6 @@ ngx_module_name=ngx_http_brotli_filter_module
 
 brotli="$ngx_addon_dir/deps/brotli/c"
 if [ ! -f "$brotli/include/brotli/encode.h" ]; then
-  brotli="/usr/local"
-fi
-if [ ! -f "$brotli/include/brotli/encode.h" ]; then
-  brotli="/usr"
-fi
-if [ ! -f "$brotli/include/brotli/encode.h" ]; then
 cat << END
 
 $0: error: \
@@ -67,7 +61,6 @@ BROTLI_OUTPUT_DIRECTORY="$brotli/../out"
 BROTLI_ENC_H="$brotli/include/brotli/encode.h \
               $brotli/include/brotli/port.h \
               $brotli/include/brotli/types.h"
-BROTLI_ENC_LIB="-lbrotlienc"
 BROTLI_ENC_LIB="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon"
 
 

--- a/filter/config
+++ b/filter/config
@@ -63,32 +63,17 @@ END
     exit 1
 fi
 
-BROTLI_LISTS_FILE="$brotli/../scripts/sources.lst"
-
-if [ -f "$BROTLI_LISTS_FILE" ]; then
-
-BROTLI_LISTS=`cat "$BROTLI_LISTS_FILE" | grep -v "#" | tr '\n' '#' | \
-              sed 's/\\\\#//g' | tr -s ' ' '+' | tr -s '#' ' ' | \
-              sed 's/+c/+$brotli/g' | sed 's/+=+/=/g'`
-for ITEM in ${BROTLI_LISTS}; do
-  VAR=`echo $ITEM | sed 's/=.*//'`
-  VAL=`echo $ITEM | sed 's/.*=//' | tr '+' ' '`
-  eval ${VAR}=\"$VAL\"
-done
-
-else  # BROTLI_LISTS_FILE
-
+BROTLI_OUTPUT_DIRECTORY="$brotli/../out"
 BROTLI_ENC_H="$brotli/include/brotli/encode.h \
               $brotli/include/brotli/port.h \
               $brotli/include/brotli/types.h"
 BROTLI_ENC_LIB="-lbrotlienc"
+BROTLI_ENC_LIB="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon"
 
-fi
 
 ngx_module_incs="$brotli/include"
 ngx_module_deps="$BROTLI_COMMON_H $BROTLI_ENC_H"
-ngx_module_srcs="$BROTLI_COMMON_C $BROTLI_ENC_C \
-                 $BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
+ngx_module_srcs="$BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
 ngx_module_libs="$BROTLI_ENC_LIB -lm"
 ngx_module_order="$ngx_module_name \
                   ngx_pagespeed \

--- a/filter/config
+++ b/filter/config
@@ -61,13 +61,12 @@ BROTLI_OUTPUT_DIRECTORY="$brotli/../out"
 BROTLI_ENC_H="$brotli/include/brotli/encode.h \
               $brotli/include/brotli/port.h \
               $brotli/include/brotli/types.h"
-BROTLI_ENC_LIB="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon"
 
 
 ngx_module_incs="$brotli/include"
-ngx_module_deps="$BROTLI_COMMON_H $BROTLI_ENC_H"
+ngx_module_deps="$BROTLI_ENC_H"
 ngx_module_srcs="$BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
-ngx_module_libs="$BROTLI_ENC_LIB -lm"
+ngx_module_libs="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon -lm"
 ngx_module_order="$ngx_module_name \
                   ngx_pagespeed \
                   ngx_http_postpone_filter_module \


### PR DESCRIPTION
This PR fix the latest commit by fixing the config file to include the correct static libraries, drop support for the sources.lst file (which no longer exists), and updates the build instructions to get people up and running quickly.

Fixes https://github.com/google/ngx_brotli/issues/148
Fixes https://github.com/google/ngx_brotli/issues/149
Fixes https://github.com/google/ngx_brotli/issues/151