### PR TITLE
Fix compile of ngx_brotli for newer nginx version (with new MSVC)

### DIFF
--- a/filter/config
+++ b/filter/config
@@ -103,7 +103,7 @@ if [ "$ngx_module_link" != DYNAMIC ]; then
                          | sed "s/$next/$next $ngx_module_name/"`
 fi
 
-if [ "$NGX_MSVC_VER" = "" ]; then
+if [ "$ngx_msvc_ver" = "" -a "$NGX_MSVC_VER" = "" ]; then
     CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 else  # MSVC
     CFLAGS="$CFLAGS -Y- -wd4127 -wd4189 -wd4201 -wd4334 -wd4702"

--- a/filter/config
+++ b/filter/config
@@ -106,7 +106,7 @@ fi
 if [ "$ngx_msvc_ver" = "" -a "$NGX_MSVC_VER" = "" ]; then
     CFLAGS="$CFLAGS -Wno-deprecated-declarations"
 else  # MSVC
-    CFLAGS="$CFLAGS -Y- -wd4127 -wd4189 -wd4201 -wd4334 -wd4702"
+    CFLAGS="$CFLAGS -FIngx_config.h -wd4127 -wd4189 -wd4201 -wd4334 -wd4702"
 fi
 
 have=NGX_HTTP_BROTLI_FILTER . auto/have

--- a/filter/config
+++ b/filter/config
@@ -58,15 +58,115 @@ END
 fi
 
 BROTLI_OUTPUT_DIRECTORY="$brotli/../out"
-BROTLI_ENC_H="$brotli/include/brotli/encode.h \
-              $brotli/include/brotli/port.h \
-              $brotli/include/brotli/types.h"
 
+if [ -d "$BROTLI_OUTPUT_DIRECTORY" -o \( "$ngx_msvc_ver" = "" -a "$NGX_MSVC_VER" = "" \) ]; then
+  BROTLI_ENC_H="$brotli/include/brotli/encode.h \
+                $brotli/include/brotli/port.h \
+                $brotli/include/brotli/types.h"
 
-ngx_module_incs="$brotli/include"
-ngx_module_deps="$BROTLI_ENC_H"
-ngx_module_srcs="$BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
-ngx_module_libs="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon -lm"
+  ngx_module_incs="$brotli/include"
+  ngx_module_deps="$BROTLI_ENC_H"
+  ngx_module_srcs="$BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
+  ngx_module_libs="-L$BROTLI_OUTPUT_DIRECTORY -lbrotlienc -lbrotlicommon -lm"
+else
+  BROTLI_COMMON_C="$brotli/common/constants.c \
+    $brotli/common/context.c \
+    $brotli/common/dictionary.c \
+    $brotli/common/platform.c \
+    $brotli/common/shared_dictionary.c \
+    $brotli/common/transform.c"
+  BROTLI_COMMON_H="$brotli/common/constants.h \
+    $brotli/common/context.h \
+    $brotli/common/dictionary.h \
+    $brotli/common/platform.h \
+    $brotli/common/shared_dictionary_internal.h \
+    $brotli/common/transform.h \
+    $brotli/common/version.h"
+  BROTLI_DEC_C="$brotli/dec/bit_reader.c \
+    $brotli/dec/decode.c \
+    $brotli/dec/huffman.c \
+    $brotli/dec/state.c"
+  BROTLI_DEC_H="$brotli/dec/bit_reader.h \
+    $brotli/dec/huffman.h \
+    $brotli/dec/prefix.h \
+    $brotli/dec/state.h"
+  BROTLI_ENC_C="$brotli/enc/backward_references.c \
+    $brotli/enc/backward_references_hq.c \
+    $brotli/enc/bit_cost.c \
+    $brotli/enc/block_splitter.c \
+    $brotli/enc/brotli_bit_stream.c \
+    $brotli/enc/cluster.c \
+    $brotli/enc/command.c \
+    $brotli/enc/compound_dictionary.c \
+    $brotli/enc/compress_fragment.c \
+    $brotli/enc/compress_fragment_two_pass.c \
+    $brotli/enc/dictionary_hash.c \
+    $brotli/enc/encode.c \
+    $brotli/enc/encoder_dict.c \
+    $brotli/enc/entropy_encode.c \
+    $brotli/enc/fast_log.c \
+    $brotli/enc/histogram.c \
+    $brotli/enc/literal_cost.c \
+    $brotli/enc/memory.c \
+    $brotli/enc/metablock.c \
+    $brotli/enc/static_dict.c \
+    $brotli/enc/utf8_util.c"
+  BROTLI_ENC_H="$brotli/enc/backward_references.h \
+    $brotli/enc/backward_references_hq.h \
+    $brotli/enc/backward_references_inc.h \
+    $brotli/enc/bit_cost.h \
+    $brotli/enc/bit_cost_inc.h \
+    $brotli/enc/block_encoder_inc.h \
+    $brotli/enc/block_splitter.h \
+    $brotli/enc/block_splitter_inc.h \
+    $brotli/enc/brotli_bit_stream.h \
+    $brotli/enc/cluster.h \
+    $brotli/enc/cluster_inc.h \
+    $brotli/enc/command.h \
+    $brotli/enc/compound_dictionary.h \
+    $brotli/enc/compress_fragment.h \
+    $brotli/enc/compress_fragment_two_pass.h \
+    $brotli/enc/dictionary_hash.h \
+    $brotli/enc/encoder_dict.h \
+    $brotli/enc/entropy_encode.h \
+    $brotli/enc/entropy_encode_static.h \
+    $brotli/enc/fast_log.h \
+    $brotli/enc/find_match_length.h \
+    $brotli/enc/hash.h \
+    $brotli/enc/hash_composite_inc.h \
+    $brotli/enc/hash_forgetful_chain_inc.h \
+    $brotli/enc/hash_longest_match64_inc.h \
+    $brotli/enc/hash_longest_match_inc.h \
+    $brotli/enc/hash_longest_match_quickly_inc.h \
+    $brotli/enc/hash_rolling_inc.h \
+    $brotli/enc/hash_to_binary_tree_inc.h \
+    $brotli/enc/histogram.h \
+    $brotli/enc/histogram_inc.h \
+    $brotli/enc/literal_cost.h \
+    $brotli/enc/memory.h \
+    $brotli/enc/metablock.h \
+    $brotli/enc/metablock_inc.h \
+    $brotli/enc/params.h \
+    $brotli/enc/prefix.h \
+    $brotli/enc/quality.h \
+    $brotli/enc/ringbuffer.h \
+    $brotli/enc/static_dict.h \
+    $brotli/enc/static_dict_lut.h \
+    $brotli/enc/utf8_util.h \
+    $brotli/enc/write_bits.h"
+  BROTLI_INCLUDE="$brotli/include/brotli/decode.h \
+    $brotli/include/brotli/encode.h \
+    $brotli/include/brotli/port.h \
+    $brotli/include/brotli/shared_dictionary.h \
+    $brotli/include/brotli/types.h"
+
+  ngx_module_incs="$brotli/include"
+  ngx_module_deps="$BROTLI_COMMON_H $BROTLI_ENC_H"
+  ngx_module_srcs="$BROTLI_COMMON_C $BROTLI_ENC_C \
+                   $BROTLI_MODULE_SRC_DIR/ngx_http_brotli_filter_module.c"
+  ngx_module_libs="$BROTLI_ENC_LIB -lm"
+fi
+
 ngx_module_order="$ngx_module_name \
                   ngx_pagespeed \
                   ngx_http_postpone_filter_module \


### PR DESCRIPTION
This PR fixes compilation of ngx_brotli for newer nginx version (with new MSVC):

1. Adjust conditional check for MSVC version to new nginx version
NGX_MSVC_VER was removed in [nginx/nginx/commit/99312be10c0edd554a40df03591ed2d905f8bd10](https://github.com/nginx/nginx/commit/99312be10c0edd554a40df03591ed2d905f8bd10)
2. Update CFLAGS for MSVC configuration: force include `ngx_config.h` for precompiled header instead of `-Y-`:
modern MSVC compilers (Visual Studio 2022 and newer) no longer recognize or support the legacy -Y- syntax
(amend to eb2f8a08c7632472b2b240f12045c4a307ec1fd7).
3. Fix MSVC build without interim cmake to out-dir, when brotli sources directly compiled to ngx_brotli
(amend to 63ca02abdcf79c9e788d2eedcc388d2335902e52)